### PR TITLE
Build Index in Webworker

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -73,7 +73,7 @@ function initSearch() {
 
   request.onload = function(){
     if (request.status >= 200 && request.status < 400) {
-      w = new Worker('assets/js/worker.js');
+      w = new Worker('/assets/js/worker.js');
       w.onmessage = function(e) {
         var index = lunr.Index.load(e.data.index);
         console.log('returned:', e.data.index, e.data.docs);

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -73,32 +73,13 @@ function initSearch() {
 
   request.onload = function(){
     if (request.status >= 200 && request.status < 400) {
-      var docs = JSON.parse(request.responseText);
-
-      lunr.tokenizer.separator = {{ site.search.tokenizer_separator | default: site.search_tokenizer_separator | default: "/[\s\-/]+/" }}
-
-      var index = lunr(function(){
-        this.ref('id');
-        this.field('title', { boost: 200 });
-        this.field('content', { boost: 2 });
-        {%- if site.search.rel_url != false %}
-        this.field('relUrl');
-        {%- endif %}
-        this.metadataWhitelist = ['position']
-
-        for (var i in docs) {
-          this.add({
-            id: i,
-            title: docs[i].title,
-            content: docs[i].content,
-            {%- if site.search.rel_url != false %}
-            relUrl: docs[i].relUrl
-            {%- endif %}
-          });
-        }
-      });
-
-      searchLoaded(index, docs);
+      w = new Worker('assets/js/worker.js');
+      w.onmessage = function(e) {
+        var index = lunr.Index.load(e.data.index);
+        console.log('returned:', e.data.index, e.data.docs);
+        searchLoaded(index, e.data.docs);
+      };
+      w.postMessage(request.responseText);
     } else {
       console.log('Error loading ajax request. Request status:' + request.status);
     }
@@ -444,6 +425,7 @@ function searchLoaded(index, docs) {
       hideSearch();
     }
   });
+  console.log('search loaded!');
 }
 {%- endif %}
 

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -1,0 +1,26 @@
+onmessage = function(e) {
+  importScripts('vendor/lunr.min.js')
+
+  var docs = JSON.parse(e.data);
+
+  lunr.tokenizer.separator = /[\s/]+/
+
+  var index = lunr(function(){
+    this.ref('id');
+    this.field('title', { boost: 200 });
+    this.field('content', { boost: 2 });
+    this.field('relUrl');
+    this.metadataWhitelist = ['position']
+
+    for (var i in docs) {
+      this.add({
+        id: i,
+        title: docs[i].title,
+        content: docs[i].content,
+        relUrl: docs[i].relUrl
+      });
+    }
+  });
+  postMessage({'docs': docs, 'index': index.toJSON()})
+}
+

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -3,13 +3,16 @@ onmessage = function(e) {
 
   var docs = JSON.parse(e.data);
 
-  lunr.tokenizer.separator = /[\s/]+/
+  lunr.tokenizer.separator = {{ site.search.tokenizer_separator | default: site.search_tokenizer_separator | default: "/[\s\-/]+/" }}
 
   var index = lunr(function(){
     this.ref('id');
     this.field('title', { boost: 200 });
     this.field('content', { boost: 2 });
+    {%- if site.search.rel_url != false %}
     this.field('relUrl');
+    {%- endif %}
+
     this.metadataWhitelist = ['position']
 
     for (var i in docs) {


### PR DESCRIPTION
Move the index building into a webworker to avoid freezing up the UI loop.

There's still a small stutter when loading the index from JSON, but it is much less noticable than before.

Potential other improvements:
* update UI to indicate when search is ready and when it is not
* pre-generate the index server-side and serve that directly